### PR TITLE
Pinning Gym to 0.21.0 to ensure compatability with Stable Baselines 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version="0.1.0",
     license="MIT",
     install_requires=[
-        "gym",
+        "gym==0.21.0",
         "imageio == 2.9.0",
         "matplotlib == 3.3.4",
         "networkx == 2.5.1",


### PR DESCRIPTION
As the new maintainers of Gym are making significant changes to how it functions at the moment, Stable Baselines 3 has chosen to pin Gym to a known stable version. Without this there are several warnings when installing YAWNING-TITAN and the tests do not run (with the newest version of Gym) - Linked to #4 