### PR TITLE
Fix typo in "Ridley 2017" reference

### DIFF
--- a/notebooks/sb3/End to End Generic Env Example - Env Creation, Agent Train and Agent Rendering.ipynb
+++ b/notebooks/sb3/End to End Generic Env Example - Env Creation, Agent Train and Agent Rendering.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This notebook provides an end to end example of creating an environment and training a Proximal Policy Optimisation (PPO) agent within it.\n",
     "\n",
-    "For the purposes of this example, we are going to first create an environment that has the same network topology as [Ridley 2017](https://www.nsa.gov.Portals/70/documents/resources/everyone/digital-media-center/publications/the-next-wave/TNW-22-1.pdf#page=9) which looks likes this.\n",
+    "For the purposes of this example, we are going to first create an environment that has the same network topology as [Ridley 2017](https://www.nsa.gov/Portals/70/documents/resources/everyone/digital-media-center/publications/the-next-wave/TNW-22-1.pdf#page=9) which looks likes this.\n",
     "\n",
     "![Ridley 2017 Environment](../../docs/source/images/18-node.gif)"
    ]


### PR DESCRIPTION
Just a typo fix in the "Ridley 2017" reference in one of the example notebooks.