### PR TITLE
fix keyboard agent str concatenation error

### DIFF
--- a/yawning_titan/agents/keyboard.py
+++ b/yawning_titan/agents/keyboard.py
@@ -57,7 +57,7 @@ class KeyboardAgent:
             actions += 1
             standard_actions += 1
 
-        node_list = ["Node " + i for i in network_interface.current_graph.get_nodes()]
+        node_list = ["Node " + str(i) for i in network_interface.current_graph.get_nodes()]
         if settings.blue.action_set.reduce_vulnerability.value:
             full_action_dict["reduce_vulnerability"] = node_list
             top_level_action_mask["reduce_vulnerability"] = actions


### PR DESCRIPTION
when using the notebook keyboard agent tutorial in the repo, there is an error (TypeError: can only concatenate str (not "Node") to str)  with the get_move_set method of the class KeyboardAgent, at line 60 (in yawning_titan/agents/keyboard.py) ; it seems like it s trying to concatenate a network_interface.current_graph.get_nodes() object to a string into the node_list list, this change should fix it