### PR TITLE
Remove redundant function call?

### DIFF
--- a/src/yawning_titan/envs/generic/generic_env.py
+++ b/src/yawning_titan/envs/generic/generic_env.py
@@ -79,8 +79,6 @@ class GenericNetworkEnv(gym.Env):
 
         self.action_space = spaces.Discrete(self.blue_actions)
 
-        self.network_interface.get_observation_size()
-
         # sets up the observation space. This is a (n+2 by n) matrix. The first two columns show the state of all the
         # nodes. The remaining n columns show the connections between the nodes (effectively the adjacency matrix)
         self.observation_space = spaces.Box(


### PR DESCRIPTION
Function call to network_interface.get_observation_size(), with no assignment